### PR TITLE
Reformulação da Seção explicativa do RUP

### DIFF
--- a/bibliografia.bib
+++ b/bibliografia.bib
@@ -1,36 +1,46 @@
 @misc{ falbo,
-       author = "Ricardo de Almeida Falbo",
-       title = "Engenharia de Requisitos: Notas de Aula",
-       year = "2012" }
+     author = "Ricardo de Almeida Falbo",
+     title = "Engenharia de Requisitos: Notas de Aula",
+     year = "2012"
+}
        
 @book{ sommerville,
-       author = "Ian Sommerville",
-       title = "Engenharia de Software",
-       edition = "8",
-       chapter = "7",
-       year = "2007" }
+     author = "Ian Sommerville",
+     title = "Engenharia de Software",
+     edition = "8",
+     chapter = "7",
+     year = "2007"
+}
        
 @misc{ nuseibeh,
-       author = "B. Nuseibeh AND S. Easterbrook",
-       title = "Requiments Engineering: A Roadmap",
-       year = "2000" }
+     author = "B. Nuseibeh AND S. Easterbrook",
+     title = "Requiments Engineering: A Roadmap",
+     year = "2000"
+}
 
 @article{ tcc_rafael_richa,
 		author = "Rafael Richa Teixeira Ananias",
 		title = "Estudo comparativo entre ferramentas de Gerência de Requisitos",
 		year = "2009",
-		URL = "http://www.cin.ufpe.br/~tg/2009-2/rrta.pdf" }
-		
+		URL = "http://www.cin.ufpe.br/~tg/2009-2/rrta.pdf"
+}
+
+@article{ kruchten,
+    author = "Philippe Kruchten AND Per Kroll",
+    title = "The Rational Unified Process made easy: a practitioner's guide to the RUP",
+    year = "2003",
+}
+	
 @article{ tese_doutorado,
 		author = "Elias Canhadas Genvigir",
 		title = "Um modelo para rastreabilidade de requisitos de software baseado em generalização de elos e atributos",
 		year = "2009",
-		URL = "http://mtc-m16c.sid.inpe.br/col/sid.inpe.br/mtc-m18@80/2009/03.02.14.17/doc/publicacao.pdf" }
+		URL = "http://mtc-m16c.sid.inpe.br/col/sid.inpe.br/mtc-m18@80/2009/03.02.14.17/doc/publicacao.pdf"
+}
 		
-@article{}
-       
 @site{ deanleffingwell,
-      title = "Scaled Agile Framework About",
-      author = "Dean Leffingwell",
-      url = "http://www.scaledagileframework.com/about/",
-      year = "2016" }
+    title = "Scaled Agile Framework About",
+    author = "Dean Leffingwell",
+    year = "2016",
+    URL = "http://www.scaledagileframework.com/about/"
+}

--- a/editaveis/secoes_principais/abordagem_er.tex
+++ b/editaveis/secoes_principais/abordagem_er.tex
@@ -53,20 +53,37 @@ A Scaled Agile dá total suporte para a implementação do SAFe, possuindo cente
   \newpage
 
   \section{RUP}
-  O Rational Unified Process (RUP) é um processo de software iterativo e incremental desenvolvido no final dos anos 90, para lidar com aplicações de larga escala robustas, escaláveis e extensíveis. Foi o primeiro processo largamente adotado que reconheceu a necessidade de estender a área de abrangência das atividades que ocorriam nas fases de iniciação, elaboração, construção e transição durante o ciclo de vida.[LEFFINGEL?] Possui uma abordagem baseada em disciplinas na atribuição de tarefas e responsabilidades em um empreendimento. [WTHREEX]
+O Rational Unified Process (RUP) é um processo de Engenharia de Software iterativo e incremental desenvolvido no final dos anos 90. Fornece uma abordagem disciplinada para se delegar tarefas e responsabilidades dentro de uma organização de desenvolvimento, cujo objetivo é assegurar a produção de \textit{software} de alta qualidade dentro de prazos e orçamentos previsíveis e controlados~\cite{kruchten}.
+
+É considerado um processo tradicional de sucesso para lidar com aplicações de larga escala robustas, escaláveis e extensíveis, por isso foi o primeiro processo largamente adotado que reconheceu a necessidade de estender a área de abrangência das atividades que ocorriam nas fases de iniciação, elaboração, construção e transição durante o ciclo de vida~\cite{deanleffingwell}.
+
     \begin{figure}[!htbp]
     \centering
     \includegraphics[scale=3.0]{figuras/Fases_do_RUP_-_portugues}
     \caption[Fases do RUP]{Fases do RUP. \footnotemark}
     \label{fases-rup}
   \end{figure}
-Este processo é composto de duas dimensões:
+Este processo é abstraído em duas dimensões estruturais:
 \begin{itemize}
 \item O eixo horizontal representa o tempo dividido nas fases do processo 	(Iniciação, Elaboração, Construção e Transição). Diz 	respeito ao aspecto dinâmico do processo quando ele é aprovado.
 \item O eixo vertical representa os aspectos estáticos do processo, as 	disciplinas, fluxos de trabalho, papéis, atividades e artefatos. 	[WTHREEX]
 \end{itemize}
 
-O objetivo do RUP é produzir software de alta qualidade atendendo as necessidades do projeto em um cronograma e orçamento previsíveis.
+Segundo Sommerville, o RUP aborda as melhores práticas verificadas empiricamente ao longo do tempo para o desenvolvimento de software~\cite{sommerville}:
+
+\begin{description}
+\item[1. Desenvolver o software iterativamente:] trabalhar com incrementos de \textit{software} com baseando-se na atribuição de prioridades para determinadas funcionalidades, entregando o mais cedo possível as características de sistema de maior prioridade no processo de desenvolvimento.
+\item[2. Gerenciar requisitos:] manter um processo de documentação sistemática dos requisitos do cliente e gerenciar mudanças nesses requisitos, avaliando o impacto geral dessas alterações antes de aceitá-las.
+\item[3. Arquiteturas baseadas em componentes:] Estruturar a arquitetura do sistema com componentes, modularizando e reduzindo a quantidade de software a ser desenvolvido e, consequentemente, diminuindo custos e riscos.
+\item[4. Modelar software visualmente:] usar modelos gráficos de UML para apresentar as visões estática e dinâmica do \textit{software}, de modo a alinhar a visão dos envolvidos no projeto, reduzindo os riscos de uma solução que não seja condizente com o real problema.
+\item[5. Verificar a qualidade do software:] garantir que o software atenda aos padrões de qualidade exigidos pelo mercado de acordo com a organização.
+\item[6. Gerenciar as mudanças do software:] controlar as mudanças no \textit{software}, fazendo o uso de procedimentos e ferramentas de gerenciamento de configuração de modo a reduzir os riscos e manter a viabilidade da construção da aplicação dentro dos prazos e custos estabelecidos.
+\end{description}
+
+Tomando como base essas características, a aplicabilidade do RUP como processo base para o suporte de novos projetos pode ser conseguida de várias maneiras. Uma delas seria usar o RUP à risca, isto é, seguir todos os métodos e processos única e exclusivamente como são propostos. O ponto positivo desta abordagem é que se nada é alterado, o RUP é essencialmente completo e detalhado. Entratanto, existe um preço muito alto a ser pago, este diz respeito à sua complexidade por vezes desnecessária. Esta abordagem automaticamente aumentaria os custos em treinamentos, projetos piloto, e algumas atividades, sendo este um fator chave para inviabilizar a aplicação pura do RUP em uma série de projetos.
+
+Outra maneira seria a adoção de outro modelo de processo mais simples que utiliza parcialmente o material do RUP como fonte de referência complementar, adequando o processo tradicional ao escopo do projeto. Desse modo, o RUP pode fazer parte de uma escolha viável para pequenos projetos e equipes assim como a apresentada neste documento.
+
   \section{Modelo de maturidade}
   Os modelos de maturidade de processos são um referencial usado para:
 \begin{itemize}


### PR DESCRIPTION
Foram adicionados textos que contemplam uma visão geral do mercado em relação ao RUP e, além disso, uma conclusão com um teor já meramente explicativo da não aplicabilidade de tal processo em nosso projeto.  
@danielteles revisa aí, o mais rápido possível pois fiz alterações estruturais na bibliografia, o que pode gerar conflitos. Após, feche a issue #17
